### PR TITLE
Added support for the standard day period type.

### DIFF
--- a/simple_dt.js
+++ b/simple_dt.js
@@ -427,7 +427,7 @@ SimpleDateFormat.prototype.makeDTF = function(pat, f1) {
 				if (part == 'period') part = 'dayperiod';
 				fn = function(part, d) {
 					var fParts = this['formatToParts'](d),
-						r0 = fParts.find(function(pp, i) { return pp['type'] == part; });
+						r0 = fParts.find(function(pp, i) { return pp['type'].toLowerCase() == part; });
 					return r0 && r0['value'];
 				}.bind(dtf, part);
 			} else { // try to extract text from longer string


### PR DESCRIPTION
Chrome has a bug - it returns the type as dayperiod instead of dayPeriod and this is probably going to change. Support both of the strings for now by lower casing the type before the comparison.